### PR TITLE
Fixing the error

### DIFF
--- a/.github/workflows/main_elearners.yml
+++ b/.github/workflows/main_elearners.yml
@@ -78,4 +78,3 @@ jobs:
           app-name: 'elearners'
           package: deploy.zip
           slot-name: 'production'
-          startup-command: 'node startup.js'


### PR DESCRIPTION
Remove `startup-command` from Azure Web App deployment because it is not supported for Windows web apps and `web.config` already handles startup.

---
<a href="https://cursor.com/background-agent?bcId=bc-53eb3a24-dd3d-4a24-8b22-efc9eb5e6dba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-53eb3a24-dd3d-4a24-8b22-efc9eb5e6dba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>