### PR TITLE
Fix the error

### DIFF
--- a/.github/workflows/main_elearners.yml
+++ b/.github/workflows/main_elearners.yml
@@ -45,8 +45,8 @@ jobs:
           cp web.config deploy-folder/
           # Copy React build files to the correct location
           cp -r client/build deploy-folder/build
-          # Copy node_modules for production (only production dependencies)
-          npm ci --only=production --prefix deploy-folder
+          # Install production dependencies (using npm install since no package-lock.json exists)
+          npm install --only=production --prefix deploy-folder
           # Create a simple package.json for deployment
           cd deploy-folder
           echo '{"name":"elearners","version":"1.0.0","main":"startup.js","scripts":{"start":"node startup.js"},"engines":{"node":"20.x"}}' > package.json


### PR DESCRIPTION
Fix build failure by changing `npm ci` to `npm install` in the deployment workflow.

The `npm ci` command was failing in the 'Prepare deployment package' step because `package-lock.json` was not present in the `deploy-folder`. This was due to `package-lock.json` being in `.gitignore` and thus not copied into the deployment directory. `npm install` is used instead as it can proceed without a pre-existing lock file.

---
<a href="https://cursor.com/background-agent?bcId=bc-076bb356-fe90-4d77-9556-e340fefa970d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-076bb356-fe90-4d77-9556-e340fefa970d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>